### PR TITLE
Update SNSP-CPU-02 README.md for Color Carrier jumper

### DIFF
--- a/installation/SNSP-CPU-01/README.md
+++ b/installation/SNSP-CPU-01/README.md
@@ -44,6 +44,9 @@
   ![](./basic_connections.jpg)
 - close _SJ32_ and _SJ61_  
   ![](./jumper.jpg)
+- if using SMR20200323 or later, **one** (but **not** both!) of the _SJ63_ jumpers must be closed for a color carrier signal.
+  - SJ63.1: (marked with a dot) outputs color carrier derived from non-dejittered clock.
+  - SJ63.2: outputs color carrier derived from dejittered clock.
 
 
 


### PR DESCRIPTION
Include notes regarding color carrier jumper SJ63, which without, results in a black and white image.
(Discovered through own experience following instructions for SNSP-CPU-02, on a SMR2020… revision).